### PR TITLE
refactor: background form-group

### DIFF
--- a/lib/components/form/form_group.dart
+++ b/lib/components/form/form_group.dart
@@ -105,7 +105,9 @@ class FormGroup extends StatelessWidget {
               ),
               suffixIcon: suffixIcon,
               filled: true,
-              fillColor: disabled ? BTColors.gray200 : backgroundColor,
+              fillColor: disabled || readonly && keyboardType != TextInputType.datetime
+                      ? BTColors.gray200
+                      : backgroundColor,
               errorBorder: OutlineInputBorder(
                 borderSide: const BorderSide(color: BTColors.danger),
                 borderRadius:


### PR DESCRIPTION
Caso o form-goup esteja desabilitado e o mesmo possua o readonly como true e seu tipo diferente TextInputType.datetime, o background dele será BTColors.gray200. Do contrário ele assume o backgroundColor.